### PR TITLE
Data types bugfix

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 class CtiborD {
-  public function intcalc (int $num1, int $num2, boolean $soucet, boolean $odcitani, boolean $nasobeni, boolean $deleni) {
+  public function intcalc (int $num1, int $num2, bool $soucet, bool $odcitani, bool $nasobeni, bool $deleni) {
     if ($soucet && !$odcitani && !$nasobeni && !$deleni)
       return $num1 + $num2;
     else if ($odcitani && !$soucet && !$nasobeni && !$deleni)
@@ -9,9 +9,9 @@ class CtiborD {
       return $num1 * $num2;
     else if ($deleni && !$soucet && !$odcitani && !$nasobeni) {
       if ($num2 == 0)
-        throw Error("Cannot divide by 2");
+        throw new Error("Cannot divide by 2");
       return intdiv($num1, $num2);
     }
-    else throw Error("Invalid configuration");
+    else throw new Error("Invalid configuration");
   }
 }


### PR DESCRIPTION
- I don't understand why are arguments `$soucet`, `$odcitani`, `$nasobeni`, `$deleni` represented as `boolean`s. Changed to `bool`.
- Error is not thrown, because there is not `new` keyword.